### PR TITLE
Fix requirements.txt to point to correct whisper library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 yt-dlp
 spleeter
-whisper
+openai-whisper
 


### PR DESCRIPTION
The package at PyPI named [whisper](https://pypi.org/project/whisper/) is an unrelated data visualization database library. For superkaraoker to work, the correct package to install with pip is [openai-whisper](https://pypi.org/project/openai-whisper/). This will install the `whisper` command line tool for speech recognition.

(In case it's not confusing enough, there's also a package called [whisper-cli](https://pypi.org/project/whisper-cli/) that installs a `whisper` command line tool to interface with OpenAI's web API – but that's not the one you need either. :))