### PR TITLE
Add installation instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,41 @@ Automatic karaoke generator based on recent neural nets. Converts any youtube li
 
 ## Installation
 
+### Linux
 
-Linux:
+Clone the repository and make output directories:
+```
+git clone https://github.com/michalvavrecka/superkaraoker.git
+cd superkaraoker
+mkdir karaoke & mkdir output & mkdir original
+```
 
-`git clone https://github.com/michalvavrecka/superkaraoker.git`
+Install dependencies and make shell scripts executable:
+```
+pip install -r requirements.txt
+sudo apt install ffmpeg
+sudo chmod +ax ./superkaraoker
+sudo chmod +ax ./multikaraoker
+```
 
-`cd superkaraoker`
+### Mac
 
-`sudo chmod +ax ./superkaraoker`
+Clone the repository and make output directories:
+```
+git clone https://github.com/michalvavrecka/superkaraoker.git
+cd superkaraoker
+mkdir karaoke & mkdir output & mkdir original
+```
 
-`sudo chmod +ax ./multikaraoker`
+Install dependencies and make shell scripts executable:
+```
+pip install -r requirements.txt
+brew install ffmpeg
+chmod 755 ./superkaraoker
+chmod 755 ./multikaraoker
+```
 
-`pip install -r requirements.txt`
-
-`sudo apt install ffmpeg`
-
-`mkdir karaoke & mkdir output & mkdir original`
-
-
-Windows: 
+### Windows
 
 Install Python from store, download and install FFmpeg then:
 


### PR DESCRIPTION
Thank you for putting together this tool! I'm just starting to learn about working with audio files and speech recognition, and this was a helpful example for me.

Installing on Mac is similar to installing on Linux, but I needed to make a couple of adjustments:
- `chmod +ax` didn't work for me – I needed to use `chmod 755`
- `apt` doesn't exist for Mac – a common equivalent is [Homebrew](https://brew.sh) (`brew`)